### PR TITLE
Rename ADAP tutorial

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -215,8 +215,8 @@
 					</li><br/>					
 					
 					<li>
-						<a href="ADAP_user_manual.pdf" target="_blank"><strong>ADAP feature detection manual</strong></a>&nbsp;&nbsp;<i class="fa fa-file-text-o" style="font-size:20px;color:#0088cc;"></i><br/>
-						This manual covers the ADAP feature detection method.
+						<a href="ADAP_user_manual.pdf" target="_blank"><strong>ADAP tutorial for preprocessing untargeted LC-MS and GC-MS metabolomics data</strong></a>&nbsp;&nbsp;<i class="fa fa-file-text-o" style="font-size:20px;color:#0088cc;"></i><br/>
+						This manual covers the ADAP modules for preprocessing LC-MS and GC-MS metabolomics data.
 					</li><br/>
 						
 					<li>


### PR DESCRIPTION
I thought that the old name doesn't completely reflect the content of ADAP tutorial anymore.